### PR TITLE
java:8-alpine and docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
-FROM java:8
+FROM java:8-alpine
 
 # Install basic packages
-RUN apt-get update && apt-get install make
+RUN apk add --update bash && rm -rf /var/cache/apk/*
 
-ENV SBT_VERSION 0.13.9
+ENV SBT_VERSION 0.13.11
 
 # Install SBT
-RUN wget https://bintray.com/artifact/download/sbt/debian/sbt-${SBT_VERSION}.deb
-RUN dpkg -i sbt-${SBT_VERSION}.deb
-RUN rm sbt-${SBT_VERSION}.deb
+WORKDIR /opt/
+ADD https://dl.bintray.com/sbt/native-packages/sbt/${SBT_VERSION}/sbt-${SBT_VERSION}.tgz .
+RUN tar xvfz sbt-${SBT_VERSION}.tgz && rm  sbt-${SBT_VERSION}.tgz
+RUN ln -s /opt/sbt/bin/sbt /usr/bin/
 
-ENV SCALA_VERSION 2.11.7
+ENV SCALA_VERSION 2.11.8
 
 # Hack for forcing SBT to install scala
 WORKDIR /tmp/scala

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # sbt-scala-docker
 
 Base docker image to work with sbt and scala
+
+## How to use
+
+### Build a sbt project
+
+Run from the directory containing your `build.sbt`
+
+    docker run --name sbt  -v $(pwd):/tmp/scala/ diorman/sbt-scala-docker sbt package
+
+
+### Interactive console
+
+    docker run --name sbt-console -it diorman/sbt-scala-docker sbt console


### PR DESCRIPTION
Hi, I've changed your Dockerfile in order to extend _java:8-alpine_ , the resulting image is ~260MB compared to ~768MB.

I've also added a very basic documentation to use you project.
